### PR TITLE
Add missing lightgallery div

### DIFF
--- a/black-and-white.html
+++ b/black-and-white.html
@@ -71,6 +71,7 @@
 
         </div>
             
+        <div class="row" id="lightgallery">
           <div class="col-sm-6 col-md-4 col-lg-3 col-xl-3 item" data-aos="fade" data-src="images/big-images/02-large.png" data-sub-html="<h4>Mount Henry</h4><p>Taken from the ridge just west of Mount Henry on a 15 mile round trip hike to summit Mount Henry in early June, 2021.</p>">
             <a href="#"><img src="images/02-small.png" alt="henry-traverse" class="img-fluid"></a>
           </div>

--- a/color.html
+++ b/color.html
@@ -71,6 +71,7 @@
 
         </div>
 
+        <div class="row" id="lightgallery">
           <div class="col-sm-6 col-md-4 col-lg-3 col-xl-3 item" data-aos="fade" data-src="images/big-images/04-large.png" data-sub-html="<h4>South Six Shooter</h4><p>Bad weather rolling in towards South Six Shooter, a desert tower in Indian Creek, UT.</p>">
             <a href="#"><img src="images/04-small.png" alt="south-six-shooter" class="img-fluid"></a>
           </div>


### PR DESCRIPTION
The "Black and White" and "Color" galleries were missing a `div`,
which resulted in the pages rendering in their mobile form even
in normal browsers.